### PR TITLE
fix: normalize addon name in texture paths

### DIFF
--- a/Frames/Frames.lua
+++ b/Frames/Frames.lua
@@ -267,7 +267,7 @@ function GLV_MainLock_OnLoad()
     -- Wait for addon to be completely initialized
     this:RegisterEvent("ADDON_LOADED");
     this:SetScript("OnEvent", function()
-        if event == "ADDON_LOADED" and arg1 == "GuideLimeVanilla" then
+        if event == "ADDON_LOADED" and arg1 == "GuidelimeVanilla" then
             -- Now GLV is available
             local locked = GLV and GLV.Settings and GLV.Settings:GetOption({"UI", "Locked"}) or false;
             
@@ -276,14 +276,14 @@ function GLV_MainLock_OnLoad()
             
             if locked then
                 -- Locked state
-                GLV_MainLock:SetNormalTexture("Interface\\AddOns\\GuideLimeVanilla\\Textures\\closed_lock")
-                GLV_MainLock:SetPushedTexture("Interface\\AddOns\\GuideLimeVanilla\\Textures\\closed_lock_down")
+                GLV_MainLock:SetNormalTexture("Interface\\AddOns\\GuidelimeVanilla\\Textures\\closed_lock")
+                GLV_MainLock:SetPushedTexture("Interface\\AddOns\\GuidelimeVanilla\\Textures\\closed_lock_down")
                 GLV_Main:SetMovable(false)
                 GLV_Main:RegisterForDrag()
             else
                 -- Unlocked state
-                GLV_MainLock:SetNormalTexture("Interface\\AddOns\\GuideLimeVanilla\\Textures\\opened_lock")
-                GLV_MainLock:SetPushedTexture("Interface\\AddOns\\GuideLimeVanilla\\Textures\\opened_lock_down")
+                GLV_MainLock:SetNormalTexture("Interface\\AddOns\\GuidelimeVanilla\\Textures\\opened_lock")
+                GLV_MainLock:SetPushedTexture("Interface\\AddOns\\GuidelimeVanilla\\Textures\\opened_lock_down")
                 GLV_Main:SetMovable(true)
                 GLV_Main:RegisterForDrag("LeftButton")
             end
@@ -578,8 +578,8 @@ function GLV_MainLock_OnClick()
 
     if locked then
         -- Unlock
-        GLV_MainLock:SetNormalTexture("Interface\\AddOns\\GuideLimeVanilla\\Textures\\opened_lock")
-        GLV_MainLock:SetPushedTexture("Interface\\AddOns\\GuideLimeVanilla\\Textures\\opened_lock_down")
+        GLV_MainLock:SetNormalTexture("Interface\\AddOns\\GuidelimeVanilla\\Textures\\opened_lock")
+        GLV_MainLock:SetPushedTexture("Interface\\AddOns\\GuidelimeVanilla\\Textures\\opened_lock_down")
         GLV_Main:SetMovable(true)
         GLV_Main:RegisterForDrag("LeftButton")
 
@@ -590,8 +590,8 @@ function GLV_MainLock_OnClick()
         -- Lock - Save current position BEFORE locking
         GLV_SaveFramePosition()
 
-        GLV_MainLock:SetNormalTexture("Interface\\AddOns\\GuideLimeVanilla\\Textures\\closed_lock")
-        GLV_MainLock:SetPushedTexture("Interface\\AddOns\\GuideLimeVanilla\\Textures\\closed_lock_down")
+        GLV_MainLock:SetNormalTexture("Interface\\AddOns\\GuidelimeVanilla\\Textures\\closed_lock")
+        GLV_MainLock:SetPushedTexture("Interface\\AddOns\\GuidelimeVanilla\\Textures\\closed_lock_down")
         GLV_Main:SetMovable(false)
         GLV_Main:RegisterForDrag("")
 

--- a/Frames/MainFrame.xml
+++ b/Frames/MainFrame.xml
@@ -94,8 +94,8 @@
                         <Offset x="10" y="-8"/>
                     </Anchor>
                 </Anchors>
-                <NormalTexture file="Interface\AddOns\GuideLimeVanilla\Textures\closed_lock"/>
-                <PushedTexture file="Interface\AddOns\GuideLimeVanilla\Textures\closed_lock_down"/>
+                <NormalTexture file="Interface\AddOns\GuidelimeVanilla\Textures\closed_lock"/>
+                <PushedTexture file="Interface\AddOns\GuidelimeVanilla\Textures\closed_lock_down"/>
                 <Scripts>
                     <OnLoad>GLV_MainLock_OnLoad()</OnLoad>
                     <OnClick>GLV_MainLock_OnClick()</OnClick>
@@ -207,8 +207,8 @@
                         <Offset x="-15" y="17"/>
                     </Anchor>
                 </Anchors>
-                <NormalTexture file="Interface\AddOns\GuideLimeVanilla\Textures\Settings"/>
-                <PushedTexture file="Interface\AddOns\GuideLimeVanilla\Textures\Settings"/>
+                <NormalTexture file="Interface\AddOns\GuidelimeVanilla\Textures\Settings"/>
+                <PushedTexture file="Interface\AddOns\GuidelimeVanilla\Textures\Settings"/>
                 <Scripts>
                     <OnClick>GLV_ToggleSettings()</OnClick>
                 </Scripts>


### PR DESCRIPTION
## Summary
- Normalizes all texture path references from `GuideLimeVanilla` to `GuidelimeVanilla` to match the actual addon folder name
- Fixes potential breakage on case-sensitive file systems (Linux)
- Affects `Frames/Frames.lua` (lock button textures) and `Frames/MainFrame.xml` (lock + settings button textures)

## Test plan
- [ ] Verify lock button icon displays correctly (locked/unlocked states)
- [ ] Verify settings button icon displays correctly
- [ ] Test on case-sensitive file system if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)