### PR TITLE
Guide frame size setting

### DIFF
--- a/Core/GuideWriter.lua
+++ b/Core/GuideWriter.lua
@@ -143,31 +143,70 @@ local function cleanupFrameChildren(frame)
     end
 end
 
--- Adjust scroll frame position based on pinned section height
+-- Maximum scroll area height when showing "all" steps (matches MainFrame.xml)
+local MaxScrollHeight = 285
+
+-- Approximate height per step (two lines + spacing + padding) for visible-steps cap
+local function getApproxStepHeight()
+    return (2 * getScaledFontLineHeight()) + CONFIG.lineSpacing + 6
+end
+
+-- Layout constants for main frame height (header to scroll top, gap, footer)
+local MainHeaderHeight = 65
+local MainPinnedGap = 5
+local MainFooterHeight = 50
+local MainMinHeight = 200
+
+-- Adjust scroll frame position based on pinned section height and GuideVisibleSteps setting.
+-- Also sets main frame height so the window shrinks when visible steps is capped.
 local function AdjustScrollFramePosition(pinnedHeight)
     local scrollFrame = getglobal("GLV_MainScrollFrame")
     local pinnedFrame = getglobal("GLV_MainPinnedSteps")
+    local mainFrame = getglobal("GLV_Main")
 
     if not scrollFrame then return end
+
+    local visibleSteps = (GLV.Settings and GLV.Settings.GetOption and GLV.Settings:GetOption({"UI", "GuideVisibleSteps"})) or 10
+    if visibleSteps == 0 then
+        visibleSteps = 10
+    end
+    local maxScrollHeight = MaxScrollHeight
+    if visibleSteps > 0 then
+        local approxStep = getApproxStepHeight()
+        local stepsBasedHeight = visibleSteps * approxStep
+        if stepsBasedHeight < MaxScrollHeight then
+            maxScrollHeight = stepsBasedHeight
+        end
+    end
 
     -- Base offset is -65 from top of GLV_Main
     local baseYOffset = -65
 
+    local scrollHeightSet
     if pinnedHeight > 0 and pinnedFrame then
         pinnedFrame:SetHeight(pinnedHeight)
         pinnedFrame:Show()
         -- Adjust Y offset to account for pinned section
-        local newYOffset = baseYOffset - pinnedHeight - 5
+        local newYOffset = baseYOffset - pinnedHeight - MainPinnedGap
+        local availableHeight = MaxScrollHeight - pinnedHeight - MainPinnedGap
+        scrollHeightSet = visibleSteps > 0 and (maxScrollHeight < availableHeight and maxScrollHeight or availableHeight) or availableHeight
         scrollFrame:ClearAllPoints()
         scrollFrame:SetPoint("TOPLEFT", GLV_Main, "TOPLEFT", 15, newYOffset)
-        scrollFrame:SetHeight(285 - pinnedHeight - 5)
+        scrollFrame:SetHeight(scrollHeightSet)
     else
         if pinnedFrame then
             pinnedFrame:Hide()
         end
+        scrollHeightSet = maxScrollHeight
         scrollFrame:ClearAllPoints()
         scrollFrame:SetPoint("TOPLEFT", GLV_Main, "TOPLEFT", 15, baseYOffset)
-        scrollFrame:SetHeight(285)
+        scrollFrame:SetHeight(scrollHeightSet)
+    end
+
+    -- Resize main frame to fit content (no empty space when visible steps is capped)
+    if mainFrame then
+        local mainHeight = MainHeaderHeight + (pinnedHeight > 0 and (pinnedHeight + MainPinnedGap) or 0) + scrollHeightSet + MainFooterHeight
+        mainFrame:SetHeight(math.max(MainMinHeight, mainHeight))
     end
 end
 

--- a/Core/GuideWriter.lua
+++ b/Core/GuideWriter.lua
@@ -166,9 +166,10 @@ local function AdjustScrollFramePosition(pinnedHeight)
 
     if not scrollFrame then return end
 
-    local visibleSteps = (GLV.Settings and GLV.Settings.GetOption and GLV.Settings:GetOption({"UI", "GuideVisibleSteps"})) or 10
-    if visibleSteps == 0 then
-        visibleSteps = 10
+    -- Guide frame size: 0 = Big (full height), 3 = Small, 6 = Medium
+    local visibleSteps = (GLV.Settings and GLV.Settings.GetOption and GLV.Settings:GetOption({"UI", "GuideVisibleSteps"}))
+    if visibleSteps == nil then
+        visibleSteps = 0
     end
     local maxScrollHeight = MaxScrollHeight
     if visibleSteps > 0 then

--- a/Frames/Frames.lua
+++ b/Frames/Frames.lua
@@ -583,6 +583,40 @@ function GLV_ApplyFrameStrata(strata)
     end
 end
 
+-- Visible steps options: 3, 5, or 10 (no "All")
+local VISIBLE_STEPS_OPTIONS = { {3, "3"}, {5, "5"}, {10, "10"} }
+
+-- Initialize visible steps dropdown (guide window step list height cap)
+function GLV_InitVisibleStepsDropdown(dropdown)
+    local current = GLV.Settings:GetOption({"UI", "GuideVisibleSteps"})
+    if current == nil or current == 0 then
+        current = 10
+        GLV.Settings:SetOption(10, {"UI", "GuideVisibleSteps"})
+    end
+
+    UIDropDownMenu_Initialize(dropdown, function()
+        for _, opt in ipairs(VISIBLE_STEPS_OPTIONS) do
+            local val, text = opt[1], opt[2]
+            local info = {}
+            info.text = text
+            info.value = val
+            info.func = function()
+                local chosen = this.value
+                UIDropDownMenu_SetSelectedValue(dropdown, chosen)
+                UIDropDownMenu_SetText(tostring(chosen), dropdown)
+                GLV.Settings:SetOption(chosen, {"UI", "GuideVisibleSteps"})
+                if GLV.RefreshGuide then
+                    GLV:RefreshGuide()
+                end
+            end
+            UIDropDownMenu_AddButton(info)
+        end
+    end)
+
+    UIDropDownMenu_SetSelectedValue(dropdown, current)
+    UIDropDownMenu_SetText(tostring(current), dropdown)
+end
+
 -- Handle navigation scale slider change
 function GLV_OnNavScaleSliderChanged(slider, settingKeys)
     local value = slider:GetValue()

--- a/Frames/Frames.lua
+++ b/Frames/Frames.lua
@@ -583,19 +583,32 @@ function GLV_ApplyFrameStrata(strata)
     end
 end
 
--- Visible steps options: 3, 5, or 10 (no "All")
-local VISIBLE_STEPS_OPTIONS = { {3, "3"}, {5, "5"}, {10, "10"} }
+-- Guide frame size: value = step-cap (0 = full height), label = Small/Medium/Big
+local FRAME_SIZE_OPTIONS = { {3, "Small"}, {6, "Medium"}, {0, "Big"} }
 
--- Initialize visible steps dropdown (guide window step list height cap)
+local function frameSizeValueToLabel(val)
+    if val == 0 then return "Big" end
+    if val == 3 then return "Small" end
+    if val == 6 then return "Medium" end
+    -- Legacy: 5 or 10 from old setting -> show as Medium
+    return "Medium"
+end
+
+-- Initialize guide frame size dropdown (scroll area height: Small/Medium/Big)
 function GLV_InitVisibleStepsDropdown(dropdown)
     local current = GLV.Settings:GetOption({"UI", "GuideVisibleSteps"})
-    if current == nil or current == 0 then
-        current = 10
-        GLV.Settings:SetOption(10, {"UI", "GuideVisibleSteps"})
+    if current == nil then
+        current = 0
+        GLV.Settings:SetOption(0, {"UI", "GuideVisibleSteps"})
+    end
+    -- Migrate legacy numbers to our three options: 5 or 10 -> Medium (6)
+    if current == 5 or current == 10 then
+        current = 6
+        GLV.Settings:SetOption(6, {"UI", "GuideVisibleSteps"})
     end
 
     UIDropDownMenu_Initialize(dropdown, function()
-        for _, opt in ipairs(VISIBLE_STEPS_OPTIONS) do
+        for _, opt in ipairs(FRAME_SIZE_OPTIONS) do
             local val, text = opt[1], opt[2]
             local info = {}
             info.text = text
@@ -603,7 +616,7 @@ function GLV_InitVisibleStepsDropdown(dropdown)
             info.func = function()
                 local chosen = this.value
                 UIDropDownMenu_SetSelectedValue(dropdown, chosen)
-                UIDropDownMenu_SetText(tostring(chosen), dropdown)
+                UIDropDownMenu_SetText(frameSizeValueToLabel(chosen), dropdown)
                 GLV.Settings:SetOption(chosen, {"UI", "GuideVisibleSteps"})
                 if GLV.RefreshGuide then
                     GLV:RefreshGuide()
@@ -614,7 +627,7 @@ function GLV_InitVisibleStepsDropdown(dropdown)
     end)
 
     UIDropDownMenu_SetSelectedValue(dropdown, current)
-    UIDropDownMenu_SetText(tostring(current), dropdown)
+    UIDropDownMenu_SetText(frameSizeValueToLabel(current), dropdown)
 end
 
 -- Handle navigation scale slider change

--- a/Frames/SettingsFrame.xml
+++ b/Frames/SettingsFrame.xml
@@ -575,7 +575,7 @@
                             <!-- Scales Card -->
                             <Frame name="$parentScalesCard">
                                 <Size>
-                                    <AbsDimension x="430" y="165"/>
+                                    <AbsDimension x="430" y="200"/>
                                 </Size>
                                 <Anchors>
                                     <Anchor point="TOPLEFT">
@@ -612,6 +612,16 @@
                                             <Anchors>
                                                 <Anchor point="TOPLEFT" RelativeTo="$parent" RelativePoint="TOPLEFT">
                                                     <Offset x="10" y="-85"/>
+                                                </Anchor>
+                                            </Anchors>
+                                            <Color r="0.42" g="0.55" b="0.83"/>
+                                        </FontString>
+                                        <!-- Visible Steps Label -->
+                                        <FontString name="GLV_SettingsDisplayPageVisibleStepsTitle" font="Fonts\FRIZQT__.TTF" text="Visible Steps" justifyH="LEFT">
+                                            <FontHeight><AbsValue val="11"/></FontHeight>
+                                            <Anchors>
+                                                <Anchor point="TOPLEFT" RelativeTo="$parent" RelativePoint="TOPLEFT">
+                                                    <Offset x="10" y="-145"/>
                                                 </Anchor>
                                             </Anchors>
                                             <Color r="0.42" g="0.55" b="0.83"/>
@@ -673,6 +683,23 @@
                                             </OnValueChanged>
                                         </Scripts>
                                     </Slider>
+
+                                    <!-- Visible Steps Dropdown -->
+                                    <Frame name="GLV_SettingsDisplayPageVisibleStepsDropdown" inherits="UIDropDownMenuTemplate">
+                                        <Anchors>
+                                            <Anchor point="TOPLEFT" RelativeTo="GLV_SettingsDisplayPageVisibleStepsTitle" RelativePoint="BOTTOMLEFT">
+                                                <Offset x="-6" y="-8"/>
+                                            </Anchor>
+                                        </Anchors>
+                                        <Scripts>
+                                            <OnLoad>
+                                                UIDropDownMenu_SetWidth(120, this);
+                                            </OnLoad>
+                                            <OnShow>
+                                                GLV_InitVisibleStepsDropdown(this);
+                                            </OnShow>
+                                        </Scripts>
+                                    </Frame>
                                 </Frames>
                             </Frame>
 

--- a/Frames/SettingsFrame.xml
+++ b/Frames/SettingsFrame.xml
@@ -616,8 +616,8 @@
                                             </Anchors>
                                             <Color r="0.42" g="0.55" b="0.83"/>
                                         </FontString>
-                                        <!-- Visible Steps Label -->
-                                        <FontString name="GLV_SettingsDisplayPageVisibleStepsTitle" font="Fonts\FRIZQT__.TTF" text="Visible Steps" justifyH="LEFT">
+                                        <!-- Guide frame size Label -->
+                                        <FontString name="GLV_SettingsDisplayPageVisibleStepsTitle" font="Fonts\FRIZQT__.TTF" text="Guide frame size" justifyH="LEFT">
                                             <FontHeight><AbsValue val="11"/></FontHeight>
                                             <Anchors>
                                                 <Anchor point="TOPLEFT" RelativeTo="$parent" RelativePoint="TOPLEFT">

--- a/Settings.lua
+++ b/Settings.lua
@@ -22,7 +22,7 @@ local defaults = {
             Layer = "HIGH",
             GuideTextScale = 1,
             NavigationScale = 1,
-            GuideVisibleSteps = 10,  -- 3, 5, or 10 visible steps
+            GuideVisibleSteps = 0,  -- 0=Big (full), 3=Small, 6=Medium (guide frame size)
         },
         CharInfo = {
             Realm = "Unknown",

--- a/Settings.lua
+++ b/Settings.lua
@@ -22,6 +22,7 @@ local defaults = {
             Layer = "HIGH",
             GuideTextScale = 1,
             NavigationScale = 1,
+            GuideVisibleSteps = 10,  -- 3, 5, or 10 visible steps
         },
         CharInfo = {
             Realm = "Unknown",


### PR DESCRIPTION
- **Configurable guide window height**  
  New setting controls how tall the step list area is; the window no longer has a fixed large height.

- **Setting: “Guide frame size”**  
  In Settings → Display: dropdown with **Small** (~3 steps), **Medium** (~6), **Big** (full height). All steps remain in the list; you scroll to see more.

- **Dynamic frame height**  
  Main guide frame height updates with the chosen size and any pinned (ongoing) steps, so there’s no big empty gap.

- **Defaults and migration**  
  Default is **Big**. 
